### PR TITLE
Corrections for 5km labels & data. self._data copy seems not needed. MOD05 specialization.

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,1 @@
+Untitled.ipynb

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ data_files = []
 
 setup(
     name="starepandas",
-    version='0.2',
+    version='0.2.1',
     description="STARE pandas extensions",
     license="MIT",
     author="Niklas Griessbaum",

--- a/starepandas/io/folder.py
+++ b/starepandas/io/folder.py
@@ -23,7 +23,7 @@ def make_row(granule_name, add_sf=False):
     if not sidecar_name:
         print('no sidecar found for {}'.format(granule_name))
         return None
-    stare_cover = starepandas.read_sidecar(sidecar_name)
+    stare_cover = starepandas.read_sidecar_cover(sidecar_name)
     row = {}
     row['granule_name'] = granule_name
     row['sidecar_name'] = sidecar_name

--- a/starepandas/staredataframe.py
+++ b/starepandas/staredataframe.py
@@ -29,7 +29,10 @@ class STAREDataFrame(geopandas.GeoDataFrame):
         
         # We need this to solve https://github.com/geopandas/geopandas/issues/1179
         # Should verify that it does not cause a performance hit
-        self._data = self._data.copy()
+        
+        # on a wing and a prayer
+        # self._data = self._data.copy()
+        # self.data = self.data.copy()
         
         # We carry over the geometry column name
         if args and isinstance(*args, geopandas.GeoDataFrame):


### PR DESCRIPTION
Various improvements found in application to MOD05 cataloging on daskhub. Labels based on outdated 1km used in previous STAREmaster versions. read_cover was pulling in the index, not the cover. I refactored the code a little so that we now have routines specifically for MOD05, hopefully making a template for future file formats. Note: the improved version of STAREmaster probably means that the sidecars on schiss need to be redone. Example application at https://github.com/SpatioTemporal/STARE-Cookbooks/blob/daskhub/contrib/jupyter/2020-ACM-SIGSPATIAL20-STARE%2BDask-Demo.ipynb