### PR TITLE
Fix vectorized package issue in the new version of geopandas and add a troubleshooting to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,23 @@ stare_amazon = samerica.stare_intersection(amazon.make_sids.iloc[0])
     
 ![Example 3](figures/amazon.png)
 
+# Troubleshooting
+## `UserWarning: pyproj unable to set database path _pyproj_global_context_initialize()` Or `Invalid projection: EPSG:4326: (Internal Proj Error: proj_create: no database context specified)`
+
+This is typically caused by a problem with the PROJ library and Geopandas. So, one potential solution for this is to do the followings:
+
+- Install proj-data with conda: `conda install -c conda-forge proj-data`
+- Install geopandas and pyproj with pip:
+    - may need to uninstall geopandas from conda: `conda remove geopandas`
+    - `pip install scipy`
+    - `pip install pyproj geopandas`
+    - May need to install shapely with conda: `conda install -c conda-forge shapely`
+    - May need to intall matlib: `conda install -c conda-forge matplotlib`
+    - Check the PROJ data directory: 
+    - `import python`
+    - `print(pyproj.datadir.get_data_dir())`
+    - `export PROJ_LIB=/path/to/proj/data`
+
 # Acknowledgments
 2018-2021 STARE development supported by NASA/ACCESS-17 grant 80NSSC18M0118.
 

--- a/starepandas/tools/trixel_conversions.py
+++ b/starepandas/tools/trixel_conversions.py
@@ -1,12 +1,12 @@
 import math
 
 import dask.dataframe
-import geopandas._vectorized as vectorized
 import numpy
 import pystare
 import shapely
 import geopandas
 from shapely.geometry import Point
+from geopandas.array import from_shapely
 
 
 def to_vertices(sids, wrap_lon=True):
@@ -545,7 +545,7 @@ def trixels_from_stareseries(sids_series, n_partitions=1, num_workers=None, wrap
         ddf = dask.dataframe.from_pandas(sids_series, npartitions=npartitions)
         meta = {'name': 'geometry'}
         res = ddf.map_partitions(lambda df:
-                                 vectorized.from_shapely(
+                                 from_shapely(
                                      trixels_from_stareseries(df, n_partitions=1, wrap_lon=wrap_lon)).flatten(),
                                  meta=meta)
         trixels_series = res.compute(scheduler='processes', num_workers=num_workers)
@@ -579,7 +579,7 @@ def split_antimeridian_series(trixels_series, n_partitions=1, num_workers=None, 
         ddf = dask.dataframe.from_pandas(trixels_series, npartitions=n_partitions)
         meta = {'trixels': 'object'}
         res = ddf.map_partitions(lambda df:
-                                 vectorized.from_shapely(
+                                 from_shapely(
                                      split_antimeridian_series(df, n_partitions=1, drop=drop)).flatten(),
                                  meta=meta)
         trixels_series = res.compute(scheduler='processes', num_workers=num_workers)


### PR DESCRIPTION
### Why?
- Starepandas is using from_shapely function from _vectorized package in geopandas
- Geopandas released a new version recently, _vectorized package was removed from geopandas package. 
- This caused the issue for starepandas
- There is a conflict between PROJ lib and Geopandas. This PR also added a suggestion to bypass this issue to README.md 
### What?
- This PR is going to fix the above issue by redirect the shapely function to geopandas.array
- Add a suggestion to bypass the conflict between PROJ lib and Geopandas to README.md